### PR TITLE
Enum improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-convert"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>", "Witnet Foundation <info@witnet.foundation>"]
 repository = "https://github.com/witnet/protobuf-convert"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,17 @@ description = "Macros for convenient serialization of Rust data structures into/
 proc-macro = true
 
 [dependencies]
-syn = "0.15"
-quote = "0.6"
-proc-macro2 = "0.4"
+darling = "0.10.0"
+heck = "0.3.1"
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"
+semver = "0.9"
 
+[dev-dependencies]
+failure = "0.1"
+protobuf = "2.8.1"
+serde = { version = "1.0.102", features = ["derive"] }
+
+[build-dependencies]
+protoc-rust = "2.0"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ features.
 First, add the dependency in `Cargo.toml`:
 
 ```
-protobuf-convert = "0.1.0"
+protobuf-convert = "0.2.0"
 ```
 
 Then, define a `ProtobufConvert` trait:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ use protobuf_convert::ProtobufConvert;
 use crate::proto::schema;
 
 #[derive(ProtobufConvert)]
-#[protobuf_convert(pb = "schema::Ping")]
+#[protobuf_convert(source = "schema::Ping")]
 struct Ping {
     nonce: u64,
 }
@@ -111,17 +111,17 @@ message Message {
 
 ```rust
 #[derive(ProtobufConvert)]
-#[protobuf_convert(pb = "schema::Ping")]
+#[protobuf_convert(source = "schema::Ping")]
 struct Ping {
     nonce: u64,
 }
 #[derive(ProtobufConvert)]
-#[protobuf_convert(pb = "schema::Pong")]
+#[protobuf_convert(source = "schema::Pong")]
 struct Pong {
     nonce: u64,
 }
 #[derive(ProtobufConvert)]
-#[protobuf_convert(pb = "schema::Message")]
+#[protobuf_convert(source = "schema::Message")]
 enum Message {
     Ping(Ping),
     Pong(Pong),
@@ -130,11 +130,35 @@ enum Message {
 
 And it just works!
 
+You can also generate `From` and `TryFrom` traits for enum variants. Note that this will not work if enum has variants
+with the same field types. To use this feature add `impl_from_trait` attribute.
+```rust
+#[derive(ProtobufConvert)]
+#[protobuf_convert(source = "schema::Message"), impl_from_trait]
+enum Message {
+    Ping(Ping),
+    Pong(Pong),
+}
+```
+`From<Ping>`, `From<Pong>` and also `TryFrom<..>` traits will be generated.
+
+Another attribute that can be used with enum is `rename`. It instructs macro to generate methods with case
+specified in attribute param. 
+```rust
+#[derive(ProtobufConvert)]
+#[protobuf_convert(source = "schema::Message"), rename(case = "snake_case")]
+enum Message {
+    Ping(Ping),
+    Pong(Pong),
+}
+```
+Currently, only snake case is supported.
+
 ## Skipping fields
 This macro also supports skipping fields in `struct`s so they are ignored when serializing, i.e they will not be mapped to any field in the schema:
 ```rust
 #[derive(ProtobufConvert)]
-#[protobuf_convert(pb = "schema::Ping")]
+#[protobuf_convert(source = "schema::Ping")]
 struct Ping {
     pub nonce: u64,
     #[protobuf_convert(skip)]
@@ -147,4 +171,3 @@ Note that you can only skip fields whose type implements the `Default` trait.
 # See also
 
 * [rust-protobuf](https://github.com/stepancheg/rust-protobuf)
-

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+extern crate protoc_rust;
+
+use protoc_rust::Customize;
+
+fn main() {
+    protoc_rust::run(protoc_rust::Args {
+        out_dir: "tests/proto",
+        input: &["tests/proto/message.proto"],
+        includes: &["tests/proto"],
+        customize: Customize {
+            ..Default::default()
+        },
+    })
+    .expect("Couldn't compile proto sources");
+}

--- a/src/pb_convert.rs
+++ b/src/pb_convert.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The Exonum Team, 2019 Witnet Foundation
+// Copyright 2019 The Exonum Team, 2019 Witnet Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,338 +12,516 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use darling::{FromDeriveInput, FromMeta};
+use heck::SnakeCase;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
-use quote::quote;
-use syn::{Attribute, Data, DeriveInput, Lit, Path};
+use quote::{quote, ToTokens};
+use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Fields, Path, Type, Variant};
+
+use std::convert::TryFrom;
 
 use super::{
-    find_word_attribute, get_name_value_attributes, PB_CONVERT_ATTRIBUTE,
-    SERDE_PB_CONVERT_ATTRIBUTE,
+    find_protobuf_convert_meta, DEFAULT_ONEOF_FIELD_NAME, PB_CONVERT_ATTRIBUTE,
+    PB_CONVERT_SKIP_ATTRIBUTE, PB_SNAKE_CASE_ATTRIBUTE,
 };
 
-fn get_protobuf_struct_path(attrs: &[Attribute]) -> Path {
-    let map_attrs = get_name_value_attributes(attrs);
-    let struct_path = map_attrs.into_iter().find_map(|nv| {
-        if nv.ident == PB_CONVERT_ATTRIBUTE {
-            match nv.lit {
-                Lit::Str(path) => Some(path.parse::<Path>().unwrap()),
-                _ => None,
-            }
-        } else {
-            None
-        }
-    });
-
-    struct_path.unwrap_or_else(|| panic!("{} attribute is not set properly.", PB_CONVERT_ATTRIBUTE))
+#[derive(Debug, FromMeta)]
+#[darling(default)]
+struct ProtobufConvertStructAttrs {
+    source: Option<Path>,
+    serde_pb_convert: bool,
 }
 
+impl Default for ProtobufConvertStructAttrs {
+    fn default() -> Self {
+        Self {
+            source: None,
+            serde_pb_convert: false,
+        }
+    }
+}
+
+impl TryFrom<&[Attribute]> for ProtobufConvertStructAttrs {
+    type Error = darling::Error;
+
+    fn try_from(args: &[Attribute]) -> Result<Self, Self::Error> {
+        find_protobuf_convert_meta(args)
+            .map(|meta| Self::from_nested_meta(&meta))
+            .unwrap_or_else(|| Ok(Self::default()))
+    }
+}
+
+#[derive(Debug, FromMeta)]
+#[darling(default)]
+struct ProtobufConvertEnumAttrs {
+    source: Option<Path>,
+    serde_pb_convert: bool,
+    impl_from_trait: bool,
+    rename: Rename,
+    oneof_field: Ident,
+}
+
+impl Default for ProtobufConvertEnumAttrs {
+    fn default() -> Self {
+        Self {
+            source: None,
+            oneof_field: syn::parse_str(DEFAULT_ONEOF_FIELD_NAME).unwrap(),
+            serde_pb_convert: false,
+            impl_from_trait: false,
+            rename: Default::default(),
+        }
+    }
+}
+
+impl TryFrom<&[Attribute]> for ProtobufConvertEnumAttrs {
+    type Error = darling::Error;
+
+    fn try_from(args: &[Attribute]) -> Result<Self, Self::Error> {
+        find_protobuf_convert_meta(args)
+            .map(|meta| Self::from_nested_meta(&meta))
+            .unwrap_or_else(|| Ok(Self::default()))
+    }
+}
+
+#[derive(Debug)]
+struct ProtobufConvertStruct {
+    name: Ident,
+    fields: Vec<(Ident, Action)>,
+    attrs: ProtobufConvertStructAttrs,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum Action {
     Convert,
     Skip,
 }
 
-fn get_field_names(input: &DeriveInput) -> Option<Vec<(Ident, Action)>> {
-    let data = match &input.data {
-        Data::Struct(x) => Some(x),
-        Data::Enum(..) => None,
-        _ => panic!("Protobuf convert can be derived for structs and enums only."),
-    };
-    data.map(|data| {
-        data.fields
-            .iter()
-            .map(|f| {
-                let mut action = Action::Convert;
-                for attr in &f.attrs {
-                    match attr.parse_meta() {
-                        Ok(syn::Meta::List(ref meta)) if meta.ident == "protobuf_convert" => {
-                            for nested in &meta.nested {
-                                match nested {
-                                    syn::NestedMeta::Meta(syn::Meta::Word(ident))
-                                        if ident == "skip" =>
-                                    {
-                                        action = Action::Skip;
-                                    }
-                                    _ => {
-                                        panic!("Unknown attribute");
-                                    }
-                                }
+fn get_field_names(data: &DataStruct) -> Vec<(Ident, Action)> {
+    data.fields
+        .iter()
+        .map(|f| {
+            let mut action = Action::Convert;
+            for attr in &f.attrs {
+                action = parse_field_meta(&attr);
+                if action == Action::Skip {
+                    break;
+                }
+            }
+            (f.ident.clone().unwrap(), action)
+        })
+        .collect()
+}
+
+fn parse_field_meta(attr: &Attribute) -> Action {
+    match attr.parse_meta() {
+        Ok(syn::Meta::List(ref meta)) => {
+            if meta.path.is_ident(PB_CONVERT_ATTRIBUTE) {
+                for nested in &meta.nested {
+                    match nested {
+                        syn::NestedMeta::Meta(meta) => {
+                            if meta.path().is_ident(PB_CONVERT_SKIP_ATTRIBUTE) {
+                                return Action::Skip;
                             }
                         }
                         _ => {
-                            // Other attributes are ignored
+                            panic!("Unknown attribute");
                         }
                     }
                 }
-                (f.ident.clone().unwrap(), action)
-            })
-            .collect()
-    })
-}
-
-fn get_field_names_enum(input: &DeriveInput) -> Option<Vec<Ident>> {
-    let data = match &input.data {
-        Data::Struct(..) => None,
-        Data::Enum(x) => Some(x),
-        _ => panic!("Protobuf convert can be derived for structs and enums only."),
-    };
-    data.map(|data| data.variants.iter().map(|f| f.ident.clone()).collect())
-}
-
-fn implement_protobuf_convert_from_pb(field_names: &[(Ident, Action)]) -> impl quote::ToTokens {
-    let mut to_convert = vec![];
-    let mut to_skip = vec![];
-    for (x, a) in field_names {
-        match a {
-            Action::Convert => to_convert.push(x),
-            Action::Skip => to_skip.push(x),
+            }
+        }
+        _ => {
+            // Other attributes are ignored
         }
     }
 
-    let getters = to_convert
-        .iter()
-        .map(|i| Ident::new(&format!("get_{}", i), Span::call_site()));
-    let our_struct_names = to_convert.clone();
-    let our_struct_names_skip = to_skip;
+    Action::Convert
+}
 
-    quote! {
-        fn from_pb(pb: Self::ProtoStruct) -> std::result::Result<Self, _FailureError> {
-          Ok(Self {
-           #( #our_struct_names: ProtobufConvert::from_pb(pb.#getters().to_owned())?, )*
-           #( #our_struct_names_skip: Default::default(), )*
-          })
-        }
+impl ProtobufConvertStruct {
+    fn from_derive_input(
+        name: Ident,
+        data: &DataStruct,
+        attrs: &[Attribute],
+    ) -> Result<Self, darling::Error> {
+        let attrs = ProtobufConvertStructAttrs::try_from(attrs)?;
+        let fields = get_field_names(data);
+
+        Ok(Self {
+            name,
+            attrs,
+            fields,
+        })
     }
 }
 
-fn implement_protobuf_convert_to_pb(field_names: &[(Ident, Action)]) -> impl quote::ToTokens {
-    let mut to_convert = vec![];
-    let mut to_skip = vec![];
-    for (x, a) in field_names {
-        match a {
-            Action::Convert => to_convert.push(x),
-            Action::Skip => to_skip.push(x),
-        }
-    }
+impl ToTokens for ProtobufConvertStruct {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let name = &self.name;
+        let pb_name = &self.attrs.source;
 
-    let setters = field_names
-        .iter()
-        .map(|i| Ident::new(&format!("set_{}", i.0), Span::call_site()));
-    let our_struct_names = to_convert;
-    let _our_struct_names_skip = to_skip;
+        let (to_convert, to_skip): (Vec<_>, Vec<_>) =
+            self.fields.iter().partition(|(_, a)| *a == Action::Convert);
 
-    quote! {
-        fn to_pb(&self) -> Self::ProtoStruct {
-            let mut msg = Self::ProtoStruct::new();
-            #( msg.#setters(ProtobufConvert::to_pb(&self.#our_struct_names).into()); )*
-            msg
-        }
-    }
-}
+        let from_pb_impl = {
+            let getters = to_convert
+                .iter()
+                .map(|(i, _)| Ident::new(&format!("get_{}", i), Span::call_site()));
+            let fields = self.fields.iter().map(|(i, _)| i).collect::<Vec<_>>();
 
-fn implement_protobuf_convert_trait(
-    name: &Ident,
-    pb_name: &Path,
-    field_names: &[(Ident, Action)],
-) -> impl quote::ToTokens {
-    let to_pb_fn = implement_protobuf_convert_to_pb(field_names);
-    let from_pb_fn = implement_protobuf_convert_from_pb(field_names);
+            let to_skip = to_skip.iter().map(|(i, _)| i).collect::<Vec<_>>();
 
-    quote! {
-        impl ProtobufConvert for #name {
-            type ProtoStruct = #pb_name;
+            quote! {
+                let inner = Self {
+                    #( #fields: ProtobufConvert::from_pb(pb.#getters().to_owned())?, )*
+                    #( #to_skip: Default::default(), )*
+                };
+                Ok(inner)
+            }
+        };
+        let to_pb_impl = {
+            let setters = to_convert
+                .iter()
+                .map(|(i, _)| Ident::new(&format!("set_{}", i), Span::call_site()));
+            let fields = self.fields.iter().map(|(i, _)| i).collect::<Vec<_>>();
 
-            #to_pb_fn
-            #from_pb_fn
-        }
-    }
-}
+            quote! {
+                let mut msg = Self::ProtoStruct::default();
+                #( msg.#setters(ProtobufConvert::to_pb(&self.#fields).into()); )*
+                msg
+            }
+        };
 
-fn implement_protobuf_convert_from_pb_enum(
-    name: &Ident,
-    pb_name: &Path,
-    field_names: &[Ident],
-) -> impl quote::ToTokens {
-    let our_struct_names = field_names.to_vec();
-    let our_struct_names1 = our_struct_names.clone();
-    let name1 = name;
-    let name = std::iter::repeat(name);
-    let mut pb_name_kind = pb_name.clone();
-    let pb_name_ident = Ident::new(
-        &format!(
-            "{}_oneof_kind",
-            pb_name
-                .segments
-                .last()
-                .unwrap()
-                .into_tuple()
-                .0
-                .ident
-                .to_string()
-        ),
-        Span::call_site(),
-    );
-    pb_name_kind
-        .segments
-        .last_mut()
-        .unwrap()
-        .into_tuple()
-        .0
-        .ident = pb_name_ident;
-    let pb_name_kind = std::iter::repeat(pb_name_kind);
+        let expanded = quote! {
+            impl ProtobufConvert for #name {
+                type ProtoStruct = #pb_name;
 
-    quote! {
-        fn from_pb(pb: Self::ProtoStruct) -> std::result::Result<Self, _FailureError> {
-            Ok(match pb.kind {
-            #(
-                Some(#pb_name_kind::#our_struct_names(x)) => {
-                    #name::#our_struct_names1(ProtobufConvert::from_pb(x)?)
+                fn from_pb(pb: Self::ProtoStruct) -> std::result::Result<Self, failure::Error> {
+                    #from_pb_impl
                 }
-            )*
-                None => return Err(failure::err_msg(format!("{}: Invalid Enum Variant", stringify!(#name1)))),
-            })
-        }
-    }
-}
 
-fn implement_protobuf_convert_to_pb_enum(
-    name: &Ident,
-    _pb_name: &Path,
-    field_names: &[Ident],
-) -> impl quote::ToTokens {
-    let setters = field_names
-        .iter()
-        .map(|i| Ident::new(&format!("set_{}", i), Span::call_site()));
-    let our_struct_names = field_names.to_vec();
-    let name = std::iter::repeat(name);
-
-    quote! {
-        fn to_pb(&self) -> Self::ProtoStruct {
-            let mut msg = Self::ProtoStruct::new();
-            match &self {
-                #(
-                #name::#our_struct_names(x) => {
-                    msg.#setters(ProtobufConvert::to_pb(x).into());
+                fn to_pb(&self) -> Self::ProtoStruct {
+                    #to_pb_impl
                 }
-                )*
             }
-            msg
+        };
+        tokens.extend(expanded);
+    }
+}
+
+#[derive(Debug)]
+struct ParsedVariant {
+    name: Ident,
+    field_name: Path,
+}
+
+impl TryFrom<&Variant> for ParsedVariant {
+    type Error = darling::Error;
+
+    fn try_from(value: &Variant) -> Result<Self, Self::Error> {
+        let name = value.ident.clone();
+        let field_name = match &value.fields {
+            Fields::Unnamed(fields) => {
+                if fields.unnamed.len() != 1 {
+                    return Err(darling::Error::unsupported_shape(
+                        "Too many fields in the enum variant",
+                    ));
+                }
+
+                match &fields.unnamed.first().unwrap().ty {
+                    Type::Path(type_path) => Ok(type_path.path.clone()),
+                    _ => Err(darling::Error::unsupported_shape(
+                        "Only variants in form Foo(Bar) are supported.",
+                    )),
+                }
+            }
+            _ => Err(darling::Error::unsupported_shape(
+                "Only variants in form Foo(Bar) are supported.",
+            )),
+        }?;
+
+        Ok(Self { name, field_name })
+    }
+}
+
+#[derive(Debug)]
+struct ProtobufConvertEnum {
+    name: Ident,
+    variants: Vec<ParsedVariant>,
+    attrs: ProtobufConvertEnumAttrs,
+}
+
+#[derive(Debug, Default, FromMeta)]
+#[darling(default)]
+pub struct Rename {
+    case: Option<String>,
+}
+
+impl ProtobufConvertEnum {
+    fn from_derive_input(
+        name: Ident,
+        data: &DataEnum,
+        attrs: &[Attribute],
+    ) -> Result<Self, darling::Error> {
+        let attrs = ProtobufConvertEnumAttrs::try_from(attrs)?;
+        let variants = data
+            .variants
+            .iter()
+            .map(ParsedVariant::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            name,
+            attrs,
+            variants,
+        })
+    }
+
+    fn impl_protobuf_convert(&self) -> impl ToTokens {
+        let pb_oneof_enum = {
+            let mut pb = self.attrs.source.clone().unwrap();
+            let oneof = pb.segments.pop().unwrap().value().ident.clone();
+            let oneof_enum = Ident::new(
+                &format!("{}_oneof_{}", oneof, &self.attrs.oneof_field),
+                Span::call_site(),
+            );
+            quote! { #pb #oneof_enum }
+        };
+        let name = &self.name;
+        let pb_name = &self.attrs.source;
+        let oneof = &self.attrs.oneof_field;
+
+        let from_pb_impl = {
+            let match_arms = self.variants.iter().map(|variant| {
+                let variant_name = self.get_variant_name(variant);
+                let pb_variant = Ident::new(variant_name.as_ref(), Span::call_site());
+                let variant_name = &variant.name;
+                let field_name = &variant.field_name;
+
+                quote! {
+                    Some(#pb_oneof_enum::#pb_variant(pb)) => {
+                        #field_name::from_pb(pb).map(#name::#variant_name)
+                    }
+                }
+            });
+
+            quote! {
+                match pb.#oneof {
+                    #( #match_arms )*
+                    None => Err(failure::format_err!("Failed to decode #name from protobuf"))
+                }
+            }
+        };
+        let to_pb_impl = {
+            let match_arms = self.variants.iter().map(|variant| {
+                let pb_variant = self.get_variant_name(variant);
+                let variant_name = &variant.name;
+
+                let setter = Ident::new(&format!("set_{}", pb_variant), Span::call_site());
+                quote! {
+                    #name::#variant_name(msg) => inner.#setter(msg.to_pb()),
+                }
+            });
+
+            quote! {
+                let mut inner = Self::ProtoStruct::new();
+                match self {
+                    #( #match_arms )*
+                }
+                inner
+            }
+        };
+
+        quote! {
+            impl ProtobufConvert for #name {
+                type ProtoStruct = #pb_name;
+
+                fn from_pb(mut pb: Self::ProtoStruct) -> std::result::Result<Self, failure::Error> {
+                    #from_pb_impl
+                }
+
+                fn to_pb(&self) -> Self::ProtoStruct {
+                    #to_pb_impl
+                }
+            }
+        }
+    }
+
+    fn impl_enum_conversions(&self) -> impl ToTokens {
+        let name = &self.name;
+
+        if self.attrs.impl_from_trait {
+            let conversions = self.variants.iter().map(|variant| {
+                let variant_name = &variant.name;
+                let field_name = &variant.field_name;
+                let variant_err = format!("Expected variant {}, but got {{:?}}", variant_name);
+
+                quote! {
+                    impl From<#field_name> for #name {
+                       fn from(variant: #field_name) -> Self {
+                           #name::#variant_name(variant)
+                       }
+                    }
+
+                    impl std::convert::TryFrom<#name> for #field_name {
+                        type Error = failure::Error;
+
+                        fn try_from(msg: #name) -> Result<Self, Self::Error> {
+                            if let #name::#variant_name(inner) = msg {
+                                Ok(inner)
+                            } else {
+                                Err(failure::format_err!(
+                                    #variant_err, msg
+                                ))
+                            }
+                        }
+                    }
+                }
+            });
+
+            quote! {
+                #( #conversions )*
+            }
+        } else {
+            quote! {}
+        }
+    }
+
+    fn get_variant_name(&self, variant: &ParsedVariant) -> String {
+        if let Some(case) = self.attrs.rename.case.as_ref() {
+            if case == PB_SNAKE_CASE_ATTRIBUTE {
+                return variant.name.to_string().to_snake_case();
+            } else {
+                panic!("Undefined case type")
+            }
+        }
+
+        variant.name.to_string()
+    }
+}
+
+impl ToTokens for ProtobufConvertEnum {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let pb_convert = self.impl_protobuf_convert();
+        let conversions = self.impl_enum_conversions();
+
+        let expanded = quote! {
+            #pb_convert
+            #conversions
+        };
+        tokens.extend(expanded)
+    }
+}
+
+#[derive(Debug)]
+enum ProtobufConvert {
+    Enum(ProtobufConvertEnum),
+    Struct(ProtobufConvertStruct),
+}
+
+impl FromDeriveInput for ProtobufConvert {
+    fn from_derive_input(input: &DeriveInput) -> Result<Self, darling::Error> {
+        match &input.data {
+            Data::Struct(data) => Ok(ProtobufConvert::Struct(
+                ProtobufConvertStruct::from_derive_input(
+                    input.ident.clone(),
+                    data,
+                    input.attrs.as_ref(),
+                )?,
+            )),
+            Data::Enum(data) => Ok(ProtobufConvert::Enum(
+                ProtobufConvertEnum::from_derive_input(
+                    input.ident.clone(),
+                    data,
+                    input.attrs.as_ref(),
+                )?,
+            )),
+            _ => Err(darling::Error::unsupported_shape(
+                "Only for enums and structs.",
+            )),
         }
     }
 }
 
-fn implement_protobuf_convert_trait_enum(
-    name: &Ident,
-    pb_name: &Path,
-    field_names: &[Ident],
-) -> impl quote::ToTokens {
-    let to_pb_fn = implement_protobuf_convert_to_pb_enum(name, pb_name, field_names);
-    let from_pb_fn = implement_protobuf_convert_from_pb_enum(name, pb_name, field_names);
+impl ProtobufConvert {
+    fn name(&self) -> &Ident {
+        match self {
+            ProtobufConvert::Enum(inner) => &inner.name,
+            ProtobufConvert::Struct(inner) => &inner.name,
+        }
+    }
 
-    quote! {
-        impl ProtobufConvert for #name {
-            type ProtoStruct = #pb_name;
+    fn serde_needed(&self) -> bool {
+        match self {
+            ProtobufConvert::Enum(inner) => inner.attrs.serde_pb_convert,
+            ProtobufConvert::Struct(inner) => inner.attrs.serde_pb_convert,
+        }
+    }
 
-            #to_pb_fn
-            #from_pb_fn
+    fn implement_serde_protobuf_convert(&self) -> impl ToTokens {
+        let name = self.name();
+        quote! {
+            impl serde::Serialize for #name {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    self.to_pb().serialize(serializer)
+                }
+            }
+
+            impl<'de> serde::Deserialize<'de> for #name {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    let pb = <#name as ProtobufConvert>::ProtoStruct::deserialize(deserializer)?;
+                    ProtobufConvert::from_pb(pb).map_err(serde::de::Error::custom)
+                }
+            }
+        }
+    }
+
+    fn implement_protobuf_convert(&self) -> impl ToTokens {
+        match self {
+            ProtobufConvert::Enum(data) => quote! { #data },
+            ProtobufConvert::Struct(data) => quote! { #data },
         }
     }
 }
 
-fn implement_serde_protobuf_convert(name: &Ident) -> proc_macro2::TokenStream {
-    quote! {
-        extern crate serde as _serde;
+impl ToTokens for ProtobufConvert {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let mod_name = Ident::new(
+            &format!("pb_convert_impl_{}", self.name()),
+            Span::call_site(),
+        );
+        let protobuf_convert = self.implement_protobuf_convert();
+        let serde_traits = if self.serde_needed() {
+            let serde = self.implement_serde_protobuf_convert();
+            quote! { #serde }
+        } else {
+            quote! {}
+        };
 
-        impl _serde::Serialize for #name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: _serde::Serializer,
-            {
-                self.to_pb().serialize(serializer)
-            }
-        }
+        let expanded = quote! {
+            mod #mod_name {
+                use super::*;
 
-        impl<'de> _serde::Deserialize<'de> for #name {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: _serde::Deserializer<'de>,
-            {
-                let pb = <#name as ProtobufConvert>::ProtoStruct::deserialize(deserializer)?;
-                ProtobufConvert::from_pb(pb).map_err(_serde::de::Error::custom)
+                use protobuf::Message as _ProtobufMessage;
+
+                #protobuf_convert
+                #serde_traits
             }
-        }
+        };
+        tokens.extend(expanded)
     }
 }
 
 pub fn implement_protobuf_convert(input: TokenStream) -> TokenStream {
-    let input: DeriveInput = syn::parse(input).unwrap();
-
-    let name = input.ident.clone();
-    let proto_struct_name = get_protobuf_struct_path(&input.attrs);
-
-    let mod_name = Ident::new(&format!("pb_convert_impl_{}", name), Span::call_site());
-
-    if let Some(field_names) = get_field_names(&input) {
-        // for structs
-        let protobuf_convert =
-            implement_protobuf_convert_trait(&name, &proto_struct_name, &field_names);
-
-        let serde_traits = {
-            let serde_needed = find_word_attribute(&input.attrs, SERDE_PB_CONVERT_ATTRIBUTE);
-            if serde_needed {
-                implement_serde_protobuf_convert(&name)
-            } else {
-                quote!()
-            }
-        };
-
-        let expanded = quote! {
-            mod #mod_name {
-                extern crate protobuf as _protobuf_crate;
-                extern crate failure as _failure;
-
-                use super::*;
-
-                use self::_protobuf_crate::Message as _ProtobufMessage;
-                use self::_failure::{bail, Error as _FailureError};
-
-                #protobuf_convert
-                #serde_traits
-            }
-        };
-
-        expanded.into()
-    } else if let Some(field_names) = get_field_names_enum(&input) {
-        // for enums
-        let protobuf_convert =
-            implement_protobuf_convert_trait_enum(&name, &proto_struct_name, &field_names);
-
-        let serde_traits = {
-            let serde_needed = find_word_attribute(&input.attrs, SERDE_PB_CONVERT_ATTRIBUTE);
-            if serde_needed {
-                implement_serde_protobuf_convert(&name)
-            } else {
-                quote!()
-            }
-        };
-
-        let expanded = quote! {
-            mod #mod_name {
-                extern crate protobuf as _protobuf_crate;
-                extern crate failure as _failure;
-
-                use super::*;
-
-                use self::_protobuf_crate::Message as _ProtobufMessage;
-                use self::_failure::{bail, Error as _FailureError};
-
-                #protobuf_convert
-                #serde_traits
-            }
-        };
-
-        expanded.into()
-    } else {
-        quote!().into()
-    }
+    let input = ProtobufConvert::from_derive_input(&syn::parse(input).unwrap())
+        .unwrap_or_else(|e| panic!("ProtobufConvert: {}", e));
+    let tokens = quote! {#input};
+    tokens.into()
 }

--- a/tests/pb_convert.rs
+++ b/tests/pb_convert.rs
@@ -1,0 +1,132 @@
+// Copyright 2019 The Exonum Team, 2019 Witnet Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+use crate::proto::ProtobufConvert;
+use protobuf_convert::ProtobufConvert;
+use std::convert::TryFrom;
+
+mod proto;
+
+#[derive(Debug, Clone, ProtobufConvert, Eq, PartialEq, Serialize, Deserialize)]
+#[protobuf_convert(source = "proto::SkipFieldsMessage")]
+struct SkipFieldsMessage {
+    id: u32,
+    #[protobuf_convert(skip)]
+    #[serde(skip)]
+    name: String,
+}
+
+#[derive(Debug, Clone, ProtobufConvert, Eq, PartialEq)]
+#[protobuf_convert(source = "proto::SimpleMessage")]
+struct Message {
+    id: u32,
+    name: String,
+}
+
+#[derive(Debug, ProtobufConvert, Eq, PartialEq)]
+#[protobuf_convert(
+    source = "proto::EnumMessage",
+    impl_from_trait,
+    rename(case = "snake_case")
+)]
+enum EnumMessage {
+    Simple(Message),
+    Skip(SkipFieldsMessage),
+}
+
+#[derive(Debug, ProtobufConvert, Eq, PartialEq)]
+#[protobuf_convert(
+    source = "proto::EnumMessageWithSimilarFields",
+    rename(case = "snake_case")
+)]
+enum EnumMessageWithSimilarFields {
+    Simple(Message),
+    Skip(Message),
+}
+
+#[derive(Debug, ProtobufConvert, Eq, PartialEq)]
+#[protobuf_convert(source = "proto::EnumMessageWithUpperCaseField")]
+enum EnumMessageWithUpperCaseField {
+    Simple(Message),
+}
+
+#[test]
+fn simple_message_roundtrip() {
+    let message = Message {
+        id: 1,
+        name: "SimpleMessage".into(),
+    };
+    let pb_message = message.to_pb();
+    let de_message = Message::from_pb(pb_message).unwrap();
+
+    assert_eq!(message, de_message);
+}
+
+#[test]
+fn skip_field_message() {
+    let message = SkipFieldsMessage {
+        id: 1,
+        name: "SimpleMessage".into(),
+    };
+    let pb_message = message.to_pb();
+    let de_message = SkipFieldsMessage::from_pb(pb_message).unwrap();
+
+    assert_eq!(message.id, de_message.id);
+    assert!(de_message.name.is_empty());
+}
+
+#[test]
+fn enum_message() {
+    let message = SkipFieldsMessage {
+        id: 1,
+        name: "SimpleMessage".into(),
+    };
+
+    let enum_message = EnumMessage::Skip(message.clone());
+
+    let pb_message = enum_message.to_pb();
+    let de_message = EnumMessage::from_pb(pb_message).unwrap();
+
+    match de_message {
+        EnumMessage::Skip(msg) => assert_eq!(msg.id, message.id),
+        _ => panic!("Deserialized message has wrong type"),
+    }
+}
+
+#[test]
+fn from_trait() {
+    let message = Message {
+        id: 1,
+        name: "message".into(),
+    };
+    let converted = EnumMessage::from(message.clone());
+
+    match converted {
+        EnumMessage::Simple(msg) => assert_eq!(msg.id, message.id),
+        _ => panic!("Converted message has wrong type"),
+    };
+
+    let skip = SkipFieldsMessage {
+        id: 1,
+        name: "skip".into(),
+    };
+    let converted = EnumMessage::from(skip.clone());
+    let err = Message::try_from(converted).unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("Expected variant Simple, but got Skip"));
+}

--- a/tests/proto/.gitignore
+++ b/tests/proto/.gitignore
@@ -1,0 +1,1 @@
+message.rs

--- a/tests/proto/message.proto
+++ b/tests/proto/message.proto
@@ -1,0 +1,44 @@
+// Copyright 2019 The Exonum Team, 2019 Witnet Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+message SimpleMessage {
+    uint32 id = 1;
+    string name = 2;
+}
+
+message SkipFieldsMessage {
+    uint32 id = 1;
+}
+
+message EnumMessage {
+    oneof kind {
+        SimpleMessage simple = 1;
+        SkipFieldsMessage skip = 2;
+    }
+}
+
+message EnumMessageWithSimilarFields {
+    oneof kind {
+        SimpleMessage simple = 1;
+        SimpleMessage skip = 2;
+    }
+}
+
+message EnumMessageWithUpperCaseField {
+    oneof kind {
+        SimpleMessage Simple = 1;
+    }
+}

--- a/tests/proto/mod.rs
+++ b/tests/proto/mod.rs
@@ -1,0 +1,54 @@
+// Copyright 2019 The Exonum Team, 2019 Witnet Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use message::*;
+
+use failure::Error;
+
+pub mod message;
+
+pub trait ProtobufConvert: Sized {
+    /// Type of the protobuf clone of Self
+    type ProtoStruct;
+
+    /// Struct -> ProtoStruct
+    fn to_pb(&self) -> Self::ProtoStruct;
+
+    /// ProtoStruct -> Struct
+    fn from_pb(pb: Self::ProtoStruct) -> Result<Self, Error>;
+}
+
+impl ProtobufConvert for String {
+    type ProtoStruct = Self;
+
+    fn to_pb(&self) -> Self::ProtoStruct {
+        self.clone()
+    }
+
+    fn from_pb(pb: Self::ProtoStruct) -> Result<Self, Error> {
+        Ok(pb)
+    }
+}
+
+impl ProtobufConvert for u32 {
+    type ProtoStruct = Self;
+
+    fn to_pb(&self) -> Self::ProtoStruct {
+        u32::from(*self)
+    }
+
+    fn from_pb(pb: Self::ProtoStruct) -> Result<Self, Error> {
+        Ok(pb)
+    }
+}


### PR DESCRIPTION
Couple of changes has been introduced in this PR:

- merged changes from exonum upstream
- update `syn`, `quote` and `proc-macro2` to version 1.0
- basic functionality unit-tests
- change `pb` attribure to `source` 