### PR TITLE
Introduce a new `with` attribute for struct fields.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-convert"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>", "Witnet Foundation <info@witnet.foundation>"]
 repository = "https://github.com/witnet/protobuf-convert"

--- a/README.md
+++ b/README.md
@@ -168,6 +168,49 @@ struct Ping {
 
 Note that you can only skip fields whose type implements the `Default` trait.
 
+## Overriding conversion rules
+This macro also supports serde-like attribute `with` for modules with the custom implementation of `from_pb` and `to_pb` conversions.
+
+Protobuf convert will use functions `$module::from_pb` and `$module::to_pb` instead of `ProtobufConvert` trait for the specified field.
+
+```rust
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum CustomId {
+    First = 5,
+    Second = 15,
+    Third = 35,
+}
+
+#[derive(Debug, Clone, ProtobufConvert, Eq, PartialEq)]
+#[protobuf_convert(source = "proto::SimpleMessage")]
+struct CustomMessage {
+    #[protobuf_convert(with = "custom_id_pb_convert")]
+    id: Option<CustomId>,
+    name: String,
+}
+
+mod custom_id_pb_convert {
+    use super::*;
+
+    pub(super) fn from_pb(pb: u32) -> Result<Option<CustomId>, failure::Error> {
+        match pb {
+            0 => Ok(None),
+            5 => Ok(Some(CustomId::First)),
+            15 => Ok(Some(CustomId::Second)),
+            35 => Ok(Some(CustomId::Third)),
+            other => Err(failure::format_err!("Unknown enum discriminant: {}", other)),
+        }
+    }
+
+    pub(super) fn to_pb(v: &Option<CustomId>) -> u32 {
+        match v {
+            Some(id) => *id as u32,
+            None => 0,
+        }
+    }
+}
+```
+
 # See also
 
 * [rust-protobuf](https://github.com/stepancheg/rust-protobuf)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Note that you can only skip fields whose type implements the `Default` trait.
 ## Overriding conversion rules
 This macro also supports serde-like attribute `with` for modules with the custom implementation of `from_pb` and `to_pb` conversions.
 
-Protobuf convert will use functions `$module::from_pb` and `$module::to_pb` instead of `ProtobufConvert` trait for the specified field.
+`protobuf-convert` will use functions `$module::from_pb` and `$module::to_pb` instead of `ProtobufConvert` trait for the specified field.
 
 ```rust
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ use proc_macro::TokenStream;
 use syn::{Attribute, NestedMeta};
 
 const PB_CONVERT_ATTRIBUTE: &str = "protobuf_convert";
-const PB_CONVERT_SKIP_ATTRIBUTE: &str = "skip";
 const PB_SNAKE_CASE_ATTRIBUTE: &str = "snake_case";
 const DEFAULT_ONEOF_FIELD_NAME: &str = "kind";
 

--- a/src/pb_convert.rs
+++ b/src/pb_convert.rs
@@ -88,20 +88,11 @@ struct ProtobufConvertStruct {
     attrs: ProtobufConvertStructAttrs,
 }
 
-#[derive(Debug, FromMeta)]
+#[derive(Debug, FromMeta, Default)]
 #[darling(default)]
 struct ProtobufConvertFieldAttrs {
     skip: bool,
     with: Option<Path>,
-}
-
-impl Default for ProtobufConvertFieldAttrs {
-    fn default() -> Self {
-        Self {
-            skip: false,
-            with: None,
-        }
-    }
 }
 
 impl TryFrom<&[Attribute]> for ProtobufConvertFieldAttrs {
@@ -152,7 +143,7 @@ impl ProtobufConvertFieldAttrs {
         let pb_getter = Ident::new(&format!("get_{}", ident), Span::call_site());
 
         let setter = match (self.skip, &self.with) {
-            // Usual setter without.
+            // Usual setter.
             (false, None) => quote! { ProtobufConvert::from_pb(pb.#pb_getter().to_owned())? },
             // Setter with the overridden Protobuf conversion.
             (false, Some(with)) => quote! { #with::from_pb(pb.#pb_getter().to_owned())? },
@@ -167,7 +158,7 @@ impl ProtobufConvertFieldAttrs {
         let pb_setter = Ident::new(&format!("set_{}", ident), Span::call_site());
 
         match (self.skip, &self.with) {
-            // Usual getter without.
+            // Usual getter.
             (false, None) => quote! {
                 msg.#pb_setter(ProtobufConvert::to_pb(&self.#ident).into());
             },


### PR DESCRIPTION
This PR adds support for serde-like `with` attribute for the custom conversion rules.

https://serde.rs/field-attrs.html#with

Example:

```rust
#[derive(Debug, Clone, Copy, Eq, PartialEq)]
enum CustomId {
    First = 5,
    Second = 15,
    Third = 35,
}

#[derive(Debug, Clone, ProtobufConvert, Eq, PartialEq)]
#[protobuf_convert(source = "proto::SimpleMessage")]
struct CustomMessage {
    #[protobuf_convert(with = "custom_id_pb_convert")]
    id: Option<CustomId>,
    name: String,
}

mod custom_id_pb_convert {
    use super::*;

    pub(super) fn from_pb(pb: u32) -> Result<Option<CustomId>, failure::Error> {
        match pb {
            0 => Ok(None),
            5 => Ok(Some(CustomId::First)),
            15 => Ok(Some(CustomId::Second)),
            35 => Ok(Some(CustomId::Third)),
            other => Err(failure::format_err!("Unknown enum discriminant: {}", other)),
        }
    }

    pub(super) fn to_pb(v: &Option<CustomId>) -> u32 {
        match v {
            Some(id) => *id as u32,
            None => 0,
        }
    }
}
```